### PR TITLE
Chain success/error the same way Angular chains these promises

### DIFF
--- a/lib/http-mock.js
+++ b/lib/http-mock.js
@@ -47,18 +47,16 @@ function mockTemplate() {
 			function wrapWithSuccessError(promise) {
 				var myPromise = promise;
 				myPromise.success = function(callback) {
-					return wrapWithSuccessError(
-						myPromise.then(function(response) {
-							return callback(response.data, response.status, response.headers, response.config);
-						})
-					);
+					myPromise.then(function(response) {
+						callback(response.data, response.status, response.headers, response.config);
+					});
+					return myPromise;
 				};
 				myPromise.error = function(callback) {
-					return wrapWithSuccessError(
-						myPromise.then(null, function(response) {
-							return callback(response.data, response.status, response.headers, response.config);
-						})
-					);
+					myPromise.then(null, function(response) {
+						callback(response.data, response.status, response.headers, response.config);
+					});
+					return myPromise;
 				};
 
 				return myPromise;


### PR DESCRIPTION
Brings mock into line with how Angular service works such that the behaviour is now the same for both.