### PR TITLE
Ability to add / remove mock request / responses dynamically.

### DIFF
--- a/lib/httpMock.js
+++ b/lib/httpMock.js
@@ -311,6 +311,22 @@ function mockTemplate() {
         newModule.requests = [];
     };
 
+    newModule.addMocks = function(expectationsToAdd) {
+        expectations = expectations.concat(expectationsToAdd);
+    };
+
+    newModule.removeMocks = function(expectationsToRemove) {
+
+        expectations.forEach(function(expectation, index) {
+            expectationsToRemove.forEach(function(expectationToRemove) {
+                if (angular.equals(expectationToRemove, expectation)) {
+                    expectations.splice(index, 1);
+                }
+            });
+        });
+
+    };
+
     return newModule;
 }
 

--- a/lib/httpMock.js
+++ b/lib/httpMock.js
@@ -331,6 +331,8 @@ function mockTemplate() {
 }
 
 function getExpectationsString(expectations){
+    if (!expectations) { return '';}
+
     var printExpectations = [];
 
     for(var i=0; i< expectations.length; i++){

--- a/lib/initData.js
+++ b/lib/initData.js
@@ -18,12 +18,12 @@ function readModuleConfig(propertyName){
 
 function getModuleConfig(){
 	var moduleConfig = {};
-	
+
 	if(module.exports.config){
 		moduleConfig.rootDirectory = readModuleConfig('rootDirectory');
 		moduleConfig.protractorConfig = readModuleConfig('protractorConfig');
 	}else{
-		moduleConfig = defaultConfig.moduleConfig; 
+		moduleConfig = defaultConfig.moduleConfig;
 	}
 
 	return moduleConfig;
@@ -44,30 +44,37 @@ function getProtractorInstance(){
 	return protractor.getInstance ? protractor.getInstance() : browser;
 }
 
-module.exports = function(mocks, skipDefaults){
-	var data = [],
-		dataModule,
-		moduleConfig = getModuleConfig(),
-		ptor = getProtractorInstance(),
-		mocksConfig = getMocksConfig(moduleConfig),
-		mockDirectory = path.join(moduleConfig.rootDirectory, mocksConfig.dir);
+function readAndIncludeMockModule(mocks, mocksConfig, moduleConfig) {
+	var dataModule, data = [];
 
-	mocks = mocks || [];
-	
-	if(!skipDefaults){
-		mocks = mocks.concat(getDefaultKeys(mocksConfig));
-	}
+	var mockDirectory = path.join(moduleConfig.rootDirectory, mocksConfig.dir);
 
 	for(var i = 0; i < mocks.length; i++){
 		dataModule = typeof mocks[i] === 'string' ? readDataModule(mockDirectory, mocks[i]) : mocks[i];
-		if(Array.isArray(dataModule)){
+
+		if (Array.isArray(dataModule)){
 			data = data.concat(dataModule);
 		}else{
 			data.push(dataModule);
 		}
-		
+
+	}
+	return data;
+}
+
+module.exports = function(mocks, skipDefaults){
+	var data,
+		ptor = getProtractorInstance(),
+		moduleConfig = getModuleConfig(),
+		mocksConfig = getMocksConfig(moduleConfig);
+
+	mocks = mocks || [];
+
+	if (!skipDefaults) {
+		mocks = mocks.concat(getDefaultKeys(mocksConfig));
 	}
 
+	data = readAndIncludeMockModule(mocks, mocksConfig, moduleConfig);
 	ptor.addMockModule('httpMock', httpMock(data));
 };
 
@@ -79,15 +86,43 @@ module.exports.teardown = function(){
 module.exports.requestsMade = function() {
 	return browser.executeAsyncScript(function () {
 		var httpMock = angular.module("httpMock");
-		var callback = arguments[arguments.length - 1]
+		var callback = arguments[arguments.length - 1];
 		callback(httpMock.requests);
 	});
 };
 
-module.exports.clearRequests = function(){
+module.exports.clearRequests = function() {
 	return browser.executeAsyncScript(function () {
 		angular.module("httpMock").clearRequests();
-		var callback = arguments[arguments.length - 1]
+		var callback = arguments[arguments.length - 1];
 		callback(true);
 	});
+};
+
+module.exports.add = function(args) {
+
+	var moduleConfig = getModuleConfig(),
+		mocksConfig = getMocksConfig(moduleConfig);
+
+	var data = readAndIncludeMockModule(args, mocksConfig, moduleConfig);
+
+	return browser.executeAsyncScript(function () {
+		angular.module("httpMock").addMocks(arguments[0]);
+		var callback = arguments[arguments.length - 1];
+		callback(true);
+	}, data);
+};
+
+module.exports.remove = function(args) {
+
+	var moduleConfig = getModuleConfig(),
+		mocksConfig = getMocksConfig(moduleConfig);
+
+	var data = readAndIncludeMockModule(args, mocksConfig, moduleConfig);
+
+	return browser.executeAsyncScript(function () {
+		angular.module("httpMock").removeMocks(arguments[0]);
+		var callback = arguments[arguments.length - 1];
+		callback(true);
+	}, data);
 };

--- a/tests/httpMock.test.js
+++ b/tests/httpMock.test.js
@@ -2,6 +2,7 @@ describe('http mock', function(){
 	var http = null,
 		module;
 
+
 	function configureMock(){
 		var mock = window.httpMock([
 			{
@@ -620,6 +621,47 @@ describe('http mock', function(){
 
 	describe('external url', function(){
 		it('should match against external URLs', function(done){
+			http({
+				method: 'GET',
+				url: 'https://test-api.com/user'
+			}).then(function(response){
+				expect(response.data).toBe('pass');
+				done();
+			});
+		});
+	});
+
+	describe('at runtime', function() {
+
+		var dynamicMocks = [{
+			request: {
+				method: 'GET',
+					path: '/user'
+			},
+			response: {
+				data: 'override'
+			}
+		}];
+
+		beforeEach(function() {
+			module.addMocks(dynamicMocks);
+		});
+		afterEach(function() {
+			module.removeMocks(dynamicMocks);
+		});
+
+		it('can add a mock', function(){
+			http({
+				method: 'GET',
+				url: 'https://test-api.com/user'
+			}).then(function(response){
+				expect(response.data).toBe('override');
+				done();
+			});
+		});
+
+		it('can remove a mock', function(){
+			module.removeMocks(dynamicMocks);
 			http({
 				method: 'GET',
 				url: 'https://test-api.com/user'


### PR DESCRIPTION
Currently there is a limitation that means you have to setup all your mock request / responses before each test.  This PR allows you to override original request / responses to give more control and more closely mimics `stub` semantics in tests.